### PR TITLE
Highlight colors are now applied to specific layers or groups [fixes #2]

### DIFF
--- a/layer_color_plugin.py
+++ b/layer_color_plugin.py
@@ -1,5 +1,14 @@
 import os
 from qgis.core import QgsMessageLog, Qgis, QgsProject
+
+try:
+  from qgis.gui import QgsLayerTreeViewItemDelegate
+  has_QgsLayerTreeViewItemDelegate = True
+except:
+  # QgsLayerTreeViewItemDelegate isn't exported
+  # Will fall back to using QStyledItemDelegate
+  has_QgsLayerTreeViewItemDelegate = False
+
 from PyQt5.QtWidgets import QColorDialog, QAction, QMenu, QStyledItemDelegate
 from PyQt5.QtGui import QColor, QPainter, QIcon
 from PyQt5.QtCore import Qt
@@ -91,7 +100,10 @@ class LayerColorPlugin:
 
             # Restore the original delegate
             if hasattr(self, "delegate") and self.delegate is not None:
-                original_delegate = QStyledItemDelegate(self.layer_tree_view)
+                if has_QgsLayerTreeViewItemDelegate:
+                    original_delegate = QgsLayerTreeViewItemDelegate(self.layer_tree_view)
+                else:
+                    original_delegate = QStyledItemDelegate(self.layer_tree_view)
                 self.layer_tree_view.setItemDelegate(original_delegate)
                 self.delegate = None
 
@@ -308,7 +320,12 @@ class LayerColorPlugin:
             log_message(f"Error loading colors: {str(e)}")
 
 
-class LayerColorDelegate(QStyledItemDelegate):
+if has_QgsLayerTreeViewItemDelegate:
+  delegateClass = QgsLayerTreeViewItemDelegate
+else:
+  delegateClass = QStyledItemDelegate
+
+class LayerColorDelegate( delegateClass ):
     def __init__(self, layer_colors, parent=None):
         super().__init__(parent)
         self.layer_colors = layer_colors

--- a/layer_color_plugin.py
+++ b/layer_color_plugin.py
@@ -7,9 +7,10 @@ try:
 except:
   # QgsLayerTreeViewItemDelegate isn't exported
   # Will fall back to using QStyledItemDelegate
+  from PyQt5.QtWidgets import QStyledItemDelegate
   has_QgsLayerTreeViewItemDelegate = False
 
-from PyQt5.QtWidgets import QColorDialog, QAction, QMenu, QStyledItemDelegate
+from PyQt5.QtWidgets import QColorDialog, QAction, QMenu
 from PyQt5.QtGui import QColor, QPainter, QIcon
 from PyQt5.QtCore import Qt
 

--- a/layer_color_plugin.py
+++ b/layer_color_plugin.py
@@ -51,7 +51,6 @@ class LayerColorPlugin:
         
     def __init__(self, iface):
         self.iface = iface
-        self.layer_colors = {}
         self.plugin_dir = os.path.dirname(__file__)
 
     def initGui(self):

--- a/layer_color_plugin.py
+++ b/layer_color_plugin.py
@@ -199,8 +199,24 @@ class LayerColorPlugin:
         if not selected_nodes:
             return
     
+        # Find color of first layer or group that has one set
+        extant_color = None
+        for layer in selected_nodes:
+            if extant_color:
+                break
+            if hasattr(layer, "customProperty"):
+                extant_color = layer.customProperty("highlight_color", None)
+                if extant_color:
+                    break
+        
         # Open the color dialog only once
-        color = QColorDialog.getColor()
+        if extant_color:
+            # A colored layer of greoup was found
+            color = QColorDialog.getColor(QColor(extant_color))
+        else:
+            # No layer of greoup had a color set
+            color = QColorDialog.getColor()
+        
         if color.isValid():
             # Check contrast
             contrast_ratio = self.calculate_contrast_ratio(color.name())

--- a/metadata.txt
+++ b/metadata.txt
@@ -22,6 +22,8 @@ changelog=
 
  * Color selector now initialized with the first custom color in the list of selected layers or groups (previously it was always initialized to white).
  
+ * If possible, QGIS additions to layer tree entries (e.g. status icons) are now displayed.  (i.e. when possible subclasses QgsLayerTreeViewItemDelegate instead of QStyledItemDelegate.)
+ 
    (changes by Alexander Hajnal – github.com/Alex-Kent)
 
  Version 0.3:

--- a/metadata.txt
+++ b/metadata.txt
@@ -20,6 +20,8 @@ changelog=
  Version 0.4:
  * Highlight colors are now applied to specific layers or groups (previously all layers or groups with the same name had the same highlight color applied).
 
+ * Color selector now initialized with the first custom color in the list of selected layers or groups (previously it was always initialized to white).
+ 
    (changes by Alexander Hajnal – github.com/Alex-Kent)
 
  Version 0.3:

--- a/metadata.txt
+++ b/metadata.txt
@@ -6,7 +6,7 @@ qgisMinimumVersion=3.0
 qgisMaximumVersion=3.99
 description=This plugin enables users to customize the background colors of layers and groups in the layer tree view, enhancing visual organization and project management. 
 about=It streamlines the organization and management of complex QGIS projects by allowing users to visually distinguish different layers or groups through custom background colors. This plugin adds a menu called "Layer Highlight Color", located above the "Properties" in the "Layer Properties" menu. Always choose pastel or lighter colors. The code implements "WCAG 2.0" contrast ratio checking to avoid colors that can make hard to read the layer text. 
-version=0.3
+version=0.4
 
 homepage=https://github.com/Spartacus1/LayerColorPlugin
 tracker=https://github.com/Spartacus1/LayerColorPlugin/issues
@@ -16,6 +16,11 @@ deprecated=False
 icon=icon.png
 
 changelog=
+
+ Version 0.4:
+ * Highlight colors are now applied to specific layers or groups (previously all layers or groups with the same name had the same highlight color applied).
+
+   (changes by Alexander Hajnal – github.com/Alex-Kent)
 
  Version 0.3:
  * Fixes a minor issue where, under certain conditions, a layer does not retain its color after the project is closed if the color change is made while it is inside a group.


### PR DESCRIPTION
The color stored in the layer/group's `highlight_color` custom property is now always used for the layer/group's color; previously the color used was determined by displayed layer/group name.

This code has has been well tested and only one non-critical issue was observed (likely a QGIS bug, see #2 and qgis/QGIS#60884 for details) [edit: it was a QGIS bug; my fix for it is in the latest/upcoming main and LTR QGIS releases].

Key changes:

* The `layer_colors` array is no longer needed and has been removed.

* At instantiation time, the `LayerColorDelegate` class constructor is passed a reference to the `LayerColorPlugin` instance rather than to the `layer_colors` array as was done previously.

* The color to use for a particular layer or group is retrieved in the `paint` method from the layer/group's `highlight_color` custom property, see lines 317-322.

**Comments**

In the `paint` method, a call to `index.data(Qt.DisplayRole)` (line 317 in the original code) returns the label as displayed in the layers tree.  This is not always the same as the layer or group name that can be retrieved using the `QgsMapLayer`'s `name()` method.  One instance where this is the case is when Show Feature Count has been enabled for a layer.

Fixes #2