### PR TITLE
Color selector now initialized with selected layer/group's current color [fixed #4]

### DIFF
--- a/layer_color_plugin.py
+++ b/layer_color_plugin.py
@@ -204,8 +204,24 @@ class LayerColorPlugin:
         if not selected_nodes:
             return
     
+        # Find color of first layer or group that has one set
+        extant_color = None
+        for layer in selected_nodes:
+            if extant_color:
+                break
+            if hasattr(layer, "customProperty"):
+                extant_color = layer.customProperty("highlight_color", None)
+                if extant_color:
+                    break
+        
         # Open the color dialog only once
-        color = QColorDialog.getColor()
+        if extant_color:
+            # A colored layer of greoup was found
+            color = QColorDialog.getColor(QColor(extant_color))
+        else:
+            # No layer of greoup had a color set
+            color = QColorDialog.getColor()
+        
         if color.isValid():
             # Check contrast
             contrast_ratio = self.calculate_contrast_ratio(color.name())

--- a/metadata.txt
+++ b/metadata.txt
@@ -17,6 +17,11 @@ icon=icon.png
 
 changelog=
 
+ Version 0.4:
+ * Color selector now initialized with the first custom color in the list of selected layers or groups (previously it was always initialized to white).
+ 
+   (changes by Alexander Hajnal – github.com/Alex-Kent)
+
  Version 0.3:
  * Fixes a minor issue where, under certain conditions, a layer does not retain its color after the project is closed if the color change is made while it is inside a group.
 


### PR DESCRIPTION
Initializes the color selector with the color assigned for the currently selected layer/group.  If multiple layers/groups are selected then the color of the first selected layer/group that has a color assigned is used.  If none of the selected layers/groups have a color assigned then the color selector is initialized with the default color (i.e. white).

(The previous behavior was to always initialize the color selector to white.)

This code has been tested and no issues were observed.

Fixes #4